### PR TITLE
remove depends statement to fix test

### DIFF
--- a/examples/zone-records/main.tf
+++ b/examples/zone-records/main.tf
@@ -23,6 +23,4 @@ module "dns_record" {
 
   zone_id = local.zone_id[0]
   records = var.records
-
-  depends_on = [module.dns_zone]
 }


### PR DESCRIPTION
Fixing this error, in the tests:
```
╷
│ Error: Module is incompatible with count, for_each, and depends_on
│ 
│   on main.tf line 27, in module "dns_record":
│   27:   depends_on = [module.dns_zone]
│ 
│ The module at module.dns_record is a legacy module which contains its own local provider configurations, and so calls
│ to it may not use the count, for_each, or depends_on arguments.
```